### PR TITLE
path validation section reflow

### DIFF
--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -351,14 +351,27 @@ DTLS 1.2.
 
 # Path Validation Procedure {#path-validation}
 
-## Basic {#regular}
-
-Note: This algorithm does not take the {{off-path}} scenario into account.
-
 The receiver that observes the peer's address or port update MUST stop sending
-any buffered application data (or limit the data sent to the unvalidated
-address to the anti-amplification limit) and initiate the return routability
-check that proceeds as follows:
+any buffered application data, or limit the data sent to the unvalidated
+address to the anti-amplification limit.
+
+It then initiates the return routability check that proceeds as described
+either in {{enhanced}} or {{regular}}, depending on whether the off-path
+attacker scenario described in {{off-path}} is to be taken into account or not.
+
+After the path validation procedure is completed, any pending send operation is
+resumed to the bound peer address.
+
+{{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
+the initiator and responder roles, broken down per protocol phase.
+
+The decision on what strategy to choose depends mainly on the threat model, but
+may also be influenced by other considerations.  Examples of impacting factors
+include: the need to minimise implementation complexity, privacy concerns, the
+need to reduce the time it takes to switch path.  The choice may be offered as
+a configuration option to the user.
+
+## Basic {#regular}
 
 1. The receiver creates a `return_routability_check` message of
    type `path_challenge` and places the unpredictable cookie into the message.
@@ -367,33 +380,21 @@ check that proceeds as follows:
 1. The peer endpoint, after successfully verifying the received
    `return_routability_check` message responds by echoing the cookie value in a
    `return_routability_check` message of type `path_response`.
-1. When the initiator receives and verifies the `return_routability_check`
-   message contains the sent cookie, it updates the peer address binding.
-1. If T expires, or the address confirmation fails, the peer address binding is
-   not updated.
-
-After this point, any pending send operation is resumed to the bound peer
-address.
-
-{{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
-the initiator and responder roles, broken down per protocol phase.
+1. When the initiator receives the `return_routability_check`
+   message and verifies that it contains the sent cookie, it updates the peer
+   address binding.
+1. If T expires the peer address binding is not updated.
 
 ## Enhanced {#enhanced}
-
-Note: This algorithm also takes the {{off-path}} scenario into account.
-
-The receiver that observes the peer's address or port update MUST stop sending
-any buffered application data (or limit the data sent to the unvalidated
-address to the anti-amplification limit) and initiate the return routability
-check that proceeds as follows:
 
 1. The receiver creates a `return_routability_check` message of
    type `path_challenge` and places the unpredictable cookie into the message.
 1. The message is sent to the previously valid address, which corresponds to the
    old path. Additionally, a timer T, see {{timer-choice}}, is started.
-1. The peer endpoint verifies the received `return_routability_check` message.
-   The action to be taken depends on the preference of the path through which
-   the message was received:
+1. If the path is still functional, the peer endpoint verifies the received
+   `return_routability_check` message.
+   The action to be taken depends on whether the path through which
+   the message was received is the preferred one or not anymore:
    - If the path through which the message was received is preferred,
    a `return_routability_check` message of type `path_response` MUST be returned.
    - If the path through which the message was received is not preferred,
@@ -408,15 +409,9 @@ check that proceeds as follows:
    - When a `return_routability_check` message of type `path_drop` was received,
    the initiator MUST perform a return routability check on the observed new
    address, as described in {{regular}}.
-1. If T expires, or the address confirmation fails, the peer address binding is
-   not updated. In this case, the initiator MUST perform a return routability
-   check on the observed new address, as described in {{regular}}.
-
-After the path validation procedure is completed, any pending send operation is
-resumed to the bound peer address.
-
-{{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
-the initiator and responder roles, broken down per protocol phase.
+1. If T expires the peer address binding is not updated. In this case, the
+   initiator MUST perform a return routability check on the observed new
+   address, as described in {{regular}}.
 
 ## Path Challenge Requirements {#path-challenge-reqs}
 

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -581,7 +581,7 @@ Parameters registry {{!IANA.tls-parameters}}, with the policy "expert review"
 Each entry in the registry must include:
 
 {:vspace}
-Value
+Value:
 : A number in the range from 0 to 255 (decimal)
 
 Description:

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -172,7 +172,14 @@ has the source address of the enclosing UDP datagram different from the one
 previously associated with that CID value, the receiver SHOULD perform a return
 routability check as described in {{path-validation}}.
 
-# Off-Path Packet Forwarding {#off-path}
+# Attacker Model
+
+RRC is not designed to counter on-path attackers.  These can never be
+distinguished from, for example, a genuine network device.  However, RRC can
+withstand off-path attackers of the type described below when the enhanced path
+validation algorithm ({{enhanced}}) is used.
+
+## Off-Path Packet Forwarding {#off-path}
 
 An off-path attacker that can observe packets might forward copies of
 genuine packets to endpoints over a different path. If the copied packet arrives before
@@ -368,7 +375,7 @@ check that proceeds as follows:
 After this point, any pending send operation is resumed to the bound peer
 address.
 
-{{path-challenge-reqs}} and {{path-response-reqs}} contain the requirements for
+{{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
 the initiator and responder roles, broken down per protocol phase.
 
 ## Enhanced {#enhanced}
@@ -408,7 +415,7 @@ check that proceeds as follows:
 After the path validation procedure is completed, any pending send operation is
 resumed to the bound peer address.
 
-{{path-challenge-reqs}} and {{path-response-reqs}} contain the requirements for
+{{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
 the initiator and responder roles, broken down per protocol phase.
 
 ## Path Challenge Requirements {#path-challenge-reqs}

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -583,16 +583,20 @@ Value
 Description:
 : a brief description of the message
 
+DTLS-Only:
+: RRC is only available in DTLS, therefore this column will be set to `Y` for
+all the entries in this registry
+
 Reference:
 : a reference document
 
 Initial entries in this sub-registry are as follows:
 
-| Value | Description    | Reference |
-|------------------------------------|
-| 0     | path_challenge | RFC-THIS  |
-| 1     | path_response  | RFC-THIS  |
-| 2     | path_drop      | RFC-THIS  |
+| Value | Description    | DTLS-Only | Reference |
+|------------------------------------------------|
+| 0     | path_challenge | Y         | RFC-THIS  |
+| 1     | path_response  | Y         | RFC-THIS  |
+| 2     | path_drop      | Y         | RFC-THIS  |
 {: #tbl-rrc-mt title="Initial Entries in RRC Message Type registry" }
 
 # Open Issues

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -359,17 +359,17 @@ It then initiates the return routability check that proceeds as described
 either in {{enhanced}} or {{regular}}, depending on whether the off-path
 attacker scenario described in {{off-path}} is to be taken into account or not.
 
+(The decision on what strategy to choose depends mainly on the threat model, but
+may also be influenced by other considerations.  Examples of impacting factors
+include: the need to minimise implementation complexity, privacy concerns, the
+need to reduce the time it takes to switch path.  The choice may be offered as
+a configuration option to the user.)
+
 After the path validation procedure is completed, any pending send operation is
 resumed to the bound peer address.
 
 {{path-challenge-reqs}} and {{path-response-reqs}} list the requirements for
 the initiator and responder roles, broken down per protocol phase.
-
-The decision on what strategy to choose depends mainly on the threat model, but
-may also be influenced by other considerations.  Examples of impacting factors
-include: the need to minimise implementation complexity, privacy concerns, the
-need to reduce the time it takes to switch path.  The choice may be offered as
-a configuration option to the user.
 
 ## Basic {#regular}
 

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -37,6 +37,9 @@ author:
     organization: Arm Limited
     email: thomas.fossati@arm.com
 
+entity:
+  SELF: "RFCthis"
+
 --- abstract
 
 This document specifies a return routability check for use in context of the
@@ -548,7 +551,7 @@ harm to connectivity.
 
 [^to-be-removed]
 
-[^to-be-removed]: RFC Editor: please replace RFC-THIS with this RFC number and remove this note.
+[^to-be-removed]: RFC Editor: please replace {{&SELF}} with this RFC number and remove this note.
 
 ## New TLS ContentType
 
@@ -565,8 +568,9 @@ extension to the `TLS ExtensionType Values` registry as described in
 
 | Value | Extension Name | TLS 1.3 | DTLS-Only  | Recommended  | Reference |
 |--------------------------------------------------------------------------|
-| TBD1  | rrc            | CH, SH  | Y          | N            | RFC-THIS  |
-{: #tbl-ext title="rrc entry in the TLS ExtensionType Values registry" }
+| TBD1  | rrc            | CH, SH  | Y          | N            | {{&SELF}} |
+{: #tbl-ext align="left"
+   title="rrc entry in the TLS ExtensionType Values registry" }
 
 ## New RRC Message Type Sub-registry
 
@@ -590,14 +594,16 @@ all the entries in this registry
 Reference:
 : a reference document
 
-Initial entries in this sub-registry are as follows:
+The initial state of this sub-registry is as follows:
 
 | Value | Description    | DTLS-Only | Reference |
 |------------------------------------------------|
-| 0     | path_challenge | Y         | RFC-THIS  |
-| 1     | path_response  | Y         | RFC-THIS  |
-| 2     | path_drop      | Y         | RFC-THIS  |
-{: #tbl-rrc-mt title="Initial Entries in RRC Message Type registry" }
+| 0     | path_challenge | Y         | {{&SELF}} |
+| 1     | path_response  | Y         | {{&SELF}} |
+| 2     | path_drop      | Y         | {{&SELF}} |
+| 3-255 | Unassigned     |           |           |
+{: #tbl-rrc-mt align="left"
+   title="Initial Entries in RRC Message Type registry" }
 
 # Open Issues
 

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -176,7 +176,7 @@ mechanisms.
 
 {{fig-off-path}} illustrates the case where a receiver receives a
 packet with a new source IP address and/or new port number. In order
-to determine whether this path change was not triggered 
+to determine whether this path change was not triggered
 by an off-path attacker, the receiver will send a RRC message of type
 `path_challenge` (1) on the old path.
 
@@ -546,19 +546,54 @@ harm to connectivity.
 
 # IANA Considerations
 
+[^to-be-removed]
+
+[^to-be-removed]: RFC Editor: please replace RFC-THIS with this RFC number and remove this note.
+
+## New TLS ContentType
+
 IANA is requested to allocate an entry to the TLS `ContentType`
 registry, for the `return_routability_check(TBD2)` message defined in
 this document. The `return_routability_check` content type is only
 applicable to DTLS 1.2 and 1.3.
 
+## New TLS ExtensionType
+
 IANA is requested to allocate the extension code point (TBD1) for the `rrc`
 extension to the `TLS ExtensionType Values` registry as described in
 {{tbl-ext}}.
 
-| Value | Extension Name | TLS 1.3 | DTLS-Only | Recommended | Reference |
+| Value | Extension Name | TLS 1.3 | DTLS-Only  | Recommended  | Reference |
 |--------------------------------------------------------------------------|
 | TBD1  | rrc            | CH, SH  | Y          | N            | RFC-THIS  |
 {: #tbl-ext title="rrc entry in the TLS ExtensionType Values registry" }
+
+## New RRC Message Type Sub-registry
+
+IANA is requested to create a new sub-registry for RRC Message Types in the TLS
+Parameters registry {{!IANA.tls-parameters}}, with the policy "expert review"
+{{!RFC8126}}.
+
+Each entry in the registry must include:
+
+{:vspace}
+Value
+: A number in the range from 0 to 255 (decimal)
+
+Description:
+: a brief description of the message
+
+Reference:
+: a reference document
+
+Initial entries in this sub-registry are as follows:
+
+| Value | Description    | Reference |
+|------------------------------------|
+| 0     | path_challenge | RFC-THIS  |
+| 1     | path_response  | RFC-THIS  |
+| 2     | path_drop      | RFC-THIS  |
+{: #tbl-rrc-mt title="Initial Entries in RRC Message Type registry" }
 
 # Open Issues
 

--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -133,7 +133,7 @@ uint64 Cookie;
 enum {
     path_challenge(0),
     path_response(1),
-    path_delete(2),
+    path_drop(2),
     reserved(3..255)
 } rrc_msg_type;
 
@@ -142,7 +142,7 @@ struct {
     select (return_routability_check.msg_type) {
         case path_challenge: Cookie;
         case path_response:  Cookie;
-        case path_delete:    Cookie;
+        case path_drop:      Cookie;
     };
 } return_routability_check;
 ~~~~
@@ -243,7 +243,7 @@ the new path.  If the sender replies with a `path_response` on the new path
 Case 2: The old path is alive but not preferred.
 
 This case is shown in {{fig-old-path-not-preferred}} whereby the sender
-replies with a `path_delete` message (2) on the old path.  This triggers
+replies with a `path_drop` message (2) on the old path.  This triggers
 the receiver to send a `path_challenge` (3) on the new path. The sender
 will reply with a `path_response` (4) on the new path, thus providing
 confirmation for the path migration.
@@ -263,7 +263,7 @@ confirmation for the path migration.
 '-----------|---|--'          '----|-+-|---------'
             | | |                  | | |
             | | 3 path-            | | 2 path-
-            | | | challenge        | | | delete
+            | | | challenge        | | | drop
             | | |   .----------.   | | |
             | | '-->|          |<--' | |
             | '-----+  Sender  +-----' |
@@ -368,7 +368,7 @@ check that proceeds as follows:
    - If the path through which the message was received is preferred,
    a `return_routability_check` message of type `path_response` MUST be returned.
    - If the path through which the message was received is not preferred,
-   a `return_routability_check` message of type `path_delete` MUST be returned.
+   a `return_routability_check` message of type `path_drop` MUST be returned.
    In either case, the peer endpoint echoes the cookie value in the response.
 1. The initiator receives and verifies that the `return_routability_check`
    message contains the previously sent cookie. The actions taken by the
@@ -376,7 +376,7 @@ check that proceeds as follows:
    - When a `return_routability_check` message of type `path_response` was received,
    the initiator MUST continue using the previously valid address, i.e. no switch
    to the new path takes place and the peer address binding is not updated.
-   - When a `return_routability_check` message of type `path_delete` was received,
+   - When a `return_routability_check` message of type `path_drop` was received,
    the initiator MUST perform a return routability check on the observed new
    address, as described in {{regular}}.
 1. If T expires, or the address confirmation fails, the peer address binding is
@@ -404,13 +404,13 @@ the initiator and responder roles, broken down per protocol phase.
   to the anti-amplification limit to probe if the path MTU (PMTU) for the new
   path is still acceptable.
 
-## Path Response/Delete Requirements {#path-response-reqs}
+## Path Response/Drop Requirements {#path-response-reqs}
 
 * The responder MUST NOT delay sending an elicited `path_response` or
-  `path_delete` messages.
-* The responder MUST send exactly one `path_response` or `path_delete` message
+  `path_drop` messages.
+* The responder MUST send exactly one `path_response` or `path_drop` message
   for each received `path_challenge`.
-* The responder MUST send the `path_response` or the `path_delete` on the path
+* The responder MUST send the `path_response` or the `path_drop` on the path
   where the corresponding `path_challenge` has been received, so that validation
   succeeds only if the path is functional in both directions. The initiator
   MUST NOT enforce this behaviour.


### PR DESCRIPTION
* factor out common text
* remove the spurious "address confirmation failure": path validation only fails on timeout
* provide further rationale for choosing between basic and enhanced

Fixes #15
Fixes #18