### PR TITLE
Add tls12_cid(25) to content types.

### DIFF
--- a/draft-ietf-tls-dtls-rrc.md
+++ b/draft-ietf-tls-dtls-rrc.md
@@ -136,6 +136,7 @@ enum {
     handshake(22),
     application_data(23),
     heartbeat(24),  /* RFC 6520 */
+    tls12_cid(25),  /* RFC 9146, DTLS 1.2 only */
     return_routability_check(TBD2), /* NEW */
     (255)
 } ContentType;


### PR DESCRIPTION
No big thing, but I would mention the related tls12_cid content type as well.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>